### PR TITLE
Document data loader config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ pip install --no-deps -e .
 
 For more detailed instructions, see our [documentation](https://LuisMartinParraMorales.github.io/metro_disruptions_intelligence/latest/installation/).
 
+## Configuration
+
+The data loader searches for your raw GTFS JSON files in the following order:
+
+1. the ``METRO_DATA_DIR`` environment variable
+2. ``config/local.yaml``
+3. ``config/default.yaml``
+
+If no valid path is found, an error is raised. Set ``METRO_DATA_DIR`` to the
+directory containing the ``RAIL_RT_*`` folders or edit ``config/local.yaml`` to
+point at that location.
+
 ## Contributing
 
 There are many ways to contribute to metro_disruptions_intelligence.

--- a/src/metro_disruptions_intelligence/data_loader.py
+++ b/src/metro_disruptions_intelligence/data_loader.py
@@ -48,22 +48,41 @@ def _load_config() -> dict:
 _cfg = _load_config()
 DATA_DIR = Path(_cfg["data_dir"]).expanduser()
 
+if not DATA_DIR.is_dir():
+    raise RuntimeError(
+        f"Data directory '{DATA_DIR}' does not exist. "
+        "Set the METRO_DATA_DIR environment variable or update config/local.yaml "
+        "with a valid path."
+    )
+
 # Define the three subdirectories (relative to DATA_DIR)
 ALERTS_DIR = DATA_DIR / "RAIL_RT_ALERTS" / "RAIL_RT_ALERTS"
 TRIP_UPDATES_DIR = DATA_DIR / "RAIL_RT_TRIP_UPDATES" / "RAIL_RT_TRIP_UPDATES"
 VEHICLE_POSITIONS_DIR = DATA_DIR / "RAIL_RT_VEHICLE_POSITIONS" / "RAIL_RT_VEHICLE_POSITIONS"
 
 
+def _ensure_dir_exists(path: Path) -> None:
+    """Raise an informative error if ``path`` does not exist."""
+    if not path.is_dir():
+        raise FileNotFoundError(
+            f"Directory '{path}' does not exist. "
+            "Set METRO_DATA_DIR to the folder containing the GTFS JSON files."
+        )
+
+
 def list_all_alert_files() -> list[Path]:
     """Return a list of all JSON files under ALERTS_DIR."""
+    _ensure_dir_exists(ALERTS_DIR)
     return sorted(ALERTS_DIR.glob("*.json"))
 
 
 def list_all_trip_update_files() -> list[Path]:
     """Return a list of all JSON files under TRIP_UPDATES_DIR."""
+    _ensure_dir_exists(TRIP_UPDATES_DIR)
     return sorted(TRIP_UPDATES_DIR.glob("*.json"))
 
 
 def list_all_vehicle_position_files() -> list[Path]:
     """Return a list of all JSON files under VEHICLE_POSITIONS_DIR."""
+    _ensure_dir_exists(VEHICLE_POSITIONS_DIR)
     return sorted(VEHICLE_POSITIONS_DIR.glob("*.json"))


### PR DESCRIPTION
## Summary
- document configuration of `METRO_DATA_DIR` in README
- improve `data_loader` error handling when paths can't be resolved

## Testing
- `PYTHONPATH=src pytest tests/test_data_loader.py -q --override-ini addopts='' -p no:xdist -p no:nbmake`

------
https://chatgpt.com/codex/tasks/task_e_6863ad7baf3c832b9820b20c1e14156a