### PR TITLE
Add parquet partition writer tests

### DIFF
--- a/tests/test_write_parquet.py
+++ b/tests/test_write_parquet.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+from metro_disruptions_intelligence.etl.write_parquet import write_df_to_partitioned_parquet
+
+
+def test_partition_directory_structure_and_prefix(tmp_path: Path) -> None:
+    ts = int(datetime(2020, 5, 3).timestamp())
+    df = pd.DataFrame({"snapshot_timestamp": [ts], "value": [1]})
+
+    out = write_df_to_partitioned_parquet(df, tmp_path, "myprefix")
+
+    expected = tmp_path / "year=2020" / "month=05" / "day=03" / "myprefix.parquet"
+    assert out == expected
+    assert out.exists()
+    assert out.parent.is_dir()
+
+
+def test_empty_dataframe_returns_none(tmp_path: Path) -> None:
+    df = pd.DataFrame({"snapshot_timestamp": [], "value": []})
+
+    out = write_df_to_partitioned_parquet(df, tmp_path, "empty")
+
+    assert out is None
+    assert not any(tmp_path.rglob("*.parquet"))


### PR DESCRIPTION
## Summary
- add tests for write_df_to_partitioned_parquet covering directory structure and empty dataframe handling

## Testing
- `pre-commit run --files tests/test_write_parquet.py`
- `pytest -o addopts='' tests/test_write_parquet.py`
- `pytest -o addopts=''`

------
https://chatgpt.com/codex/tasks/task_e_6863ad7c709c832bb9982171016a4458