### PR TITLE
Add GTFS static v2 downloader

### DIFF
--- a/src/metro_disruptions_intelligence/etl/__init__.py
+++ b/src/metro_disruptions_intelligence/etl/__init__.py
@@ -3,10 +3,12 @@
 from .static_ingest import ingest_static_gtfs
 from .ingest_rt import ingest_all_rt, union_all_feeds
 from .replay_stream import replay_stream
+from .fetch_static_v2 import download_and_extract
 
 __all__ = [
     "ingest_static_gtfs",
     "ingest_all_rt",
     "union_all_feeds",
     "replay_stream",
+    "download_and_extract",
 ]

--- a/src/metro_disruptions_intelligence/etl/fetch_static_v2.py
+++ b/src/metro_disruptions_intelligence/etl/fetch_static_v2.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from datetime import date, datetime
+from pathlib import Path
+from typing import Iterable
+
+import requests
+from tqdm import tqdm
+import zipfile
+import shutil
+
+
+API_ROOT = "https://api.transport.nsw.gov.au/v2/gtfs/schedule"
+
+
+def _stream_download(url: str, headers: dict[str, str], dest: Path) -> None:
+    """Download ``url`` to ``dest`` streaming in 1MB chunks."""
+    with requests.get(url, headers=headers, stream=True) as r:
+        if r.status_code == 404:
+            print("operator slug not found")
+            raise SystemExit(1)
+        if r.status_code == 403:
+            print("invalid API key")
+            raise SystemExit(1)
+        if not r.ok:
+            print(f"HTTP error {r.status_code}")
+            raise SystemExit(1)
+        ctype = r.headers.get("Content-Type", "")
+        if not ctype.startswith("application/zip"):
+            print("unexpected content type")
+            raise SystemExit(1)
+        total = int(r.headers.get("Content-Length", 0))
+        with open(dest, "wb") as fh:
+            with tqdm(
+                total=total,
+                unit="B",
+                unit_scale=True,
+                unit_divisor=1024,
+            ) as bar:
+                for chunk in r.iter_content(chunk_size=1024 * 1024):
+                    if chunk:
+                        fh.write(chunk)
+                        bar.update(len(chunk))
+
+
+def _extract_zip(zip_path: Path, out_dir: Path, force: bool) -> int:
+    """Extract ``zip_path`` into ``out_dir`` respecting ``force`` flag."""
+    count = 0
+    with zipfile.ZipFile(zip_path) as zf:
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+            dest = out_dir / info.filename
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            mtime = datetime(*info.date_time).timestamp()
+            if dest.exists() and not force:
+                same_size = dest.stat().st_size == info.file_size
+                if same_size and int(dest.stat().st_mtime) == int(mtime):
+                    continue
+            with zf.open(info) as src, open(dest, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            os.utime(dest, (mtime, mtime))
+            count += 1
+    return count
+
+
+def download_and_extract(
+    api_key: str,
+    operator: str,
+    out_root: Path,
+    *,
+    force: bool = False,
+    skip_if_exists: bool = True,
+) -> Path:
+    """Download the static feed for ``operator`` and extract it."""
+    out_root = Path(out_root)
+    date_str = date.today().isoformat()
+    feeds_dir = out_root / "static_feeds"
+    feeds_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = feeds_dir / f"{date_str}_{operator}.zip"
+
+    if not (skip_if_exists and zip_path.exists()):
+        url = f"{API_ROOT}/{operator}"
+        headers = {"Authorization": f"apikey {api_key}"}
+        _stream_download(url, headers, zip_path)
+    else:
+        logging.info("Using cached file %s", zip_path)
+
+    out_dir = out_root / "static"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    extracted = _extract_zip(zip_path, out_dir, force)
+    size_mb = zip_path.stat().st_size / 1024 / 1024
+    print(
+        f"\u2713 downloaded {size_mb:.0f} MB  \u2794  {zip_path} ({extracted} files extracted)"
+    )
+    return out_dir
+
+
+def _parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Download gtfs-static v2 feed")
+    parser.add_argument("--api_key", required=True, help="TfNSW API key")
+    parser.add_argument("--operator", required=True, help="Operator slug")
+    parser.add_argument("--out_root", type=Path, default=Path("data"), help="Output root directory")
+    parser.add_argument("--force", action="store_true", help="Force overwrite existing files")
+    parser.add_argument("--skip_if_exists", action="store_true", help="Skip download if zip already exists")
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = _parse_args(argv)
+    download_and_extract(
+        args.api_key,
+        args.operator,
+        args.out_root,
+        force=args.force,
+        skip_if_exists=args.skip_if_exists,
+    )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
+    main()

--- a/tests/test_fetch_static_v2.py
+++ b/tests/test_fetch_static_v2.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import io
+import zipfile
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+import sys
+import types
+import importlib.util
+
+sys.modules.setdefault("duckdb", types.ModuleType("duckdb"))
+sys.modules.setdefault("pyarrow", types.ModuleType("pyarrow"))
+requests_mod = types.ModuleType("requests")
+requests_mod.get = lambda *a, **k: None
+sys.modules.setdefault("requests", requests_mod)
+tqdm_mod = types.ModuleType("tqdm")
+def fake_tqdm(*args, **kwargs):
+    class Dummy:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def update(self, n):
+            pass
+
+    return Dummy()
+
+tqdm_mod.tqdm = fake_tqdm
+sys.modules.setdefault("tqdm", tqdm_mod)
+
+spec = importlib.util.spec_from_file_location(
+    "fetch_static_v2",
+    Path(__file__).parents[1] / "src" / "metro_disruptions_intelligence" / "etl" / "fetch_static_v2.py",
+)
+fetch_static_v2 = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(fetch_static_v2)
+
+
+class FakeResp:
+    def __init__(self, data: bytes):
+        self.status_code = 200
+        self.headers = {
+            "Content-Type": "application/zip",
+            "Content-Length": str(len(data)),
+        }
+        self._data = data
+        self.ok = True
+
+    def iter_content(self, chunk_size: int = 1024 * 1024):
+        for i in range(0, len(self._data), chunk_size):
+            yield self._data[i : i + chunk_size]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def make_zip_bytes() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("stops.txt", "id,name\n1,A\n")
+        zf.writestr("routes.txt", "id,name\n1,R\n")
+    return buf.getvalue()
+
+
+def test_download_and_extract(monkeypatch, tmp_path):
+    data = make_zip_bytes()
+    monkeypatch.setattr(fetch_static_v2, "date", type("D", (), {"today": staticmethod(lambda: date(2025, 3, 31))}))
+    monkeypatch.setattr(fetch_static_v2.requests, "get", lambda *a, **k: FakeResp(data))
+    out = fetch_static_v2.download_and_extract("key", "metro", tmp_path, skip_if_exists=False)
+    zip_path = tmp_path / "static_feeds" / "2025-03-31_metro.zip"
+    assert zip_path.exists()
+    extracted = sorted((tmp_path / "static").glob("*.txt"))
+    assert {p.name for p in extracted} == {"stops.txt", "routes.txt"}
+    assert out == tmp_path / "static"


### PR DESCRIPTION
## Summary
- add `download_and_extract` utility to fetch static GTFS v2 data
- expose the function from `etl` package
- provide unit test covering download and extraction logic

## Testing
- `PYTHONPATH=src pytest -q tests/test_fetch_static_v2.py -o addopts=`
- `PYTHONPATH=src pytest -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_6863f03bf194832ba3fa09b463a1bd06