### PR TITLE
Add RT processing notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ If no valid path is found, an error is raised. Set ``METRO_DATA_DIR`` to the
 directory containing the ``RAIL_RT_*`` folders or edit ``config/local.yaml`` to
 point at that location.
 
+## Processing realtime data
+
+To convert raw GTFS-Realtime snapshots into partitioned Parquet files use the
+``ingest_all_rt`` helper.  The easiest way is to open the notebook
+``notebooks/01_process_all_rt.ipynb`` and run the cells.  This will read all
+JSON files under ``data/raw`` and overwrite any existing output under
+``data/processed/rt``.
+
+Alternatively, the same process can be executed from the command line:
+
+```bash
+python -m metro_disruptions_intelligence.etl.ingest_rt data/raw --processed-root data/processed/rt
+```
+
+
 ## Contributing
 
 There are many ways to contribute to metro_disruptions_intelligence.

--- a/notebooks/01_process_all_rt.ipynb
+++ b/notebooks/01_process_all_rt.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "efa50fa6",
+   "metadata": {},
+   "source": [
+    "# Process all realtime JSON files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18dbb836",
+   "metadata": {},
+   "source": [
+    "This notebook parses all GTFS realtime JSON files in `data/raw` and writes processed Parquet files to `data/processed/rt`. Existing files will be overwritten."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "debe35bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from metro_disruptions_intelligence.etl.ingest_rt import ingest_all_rt, union_all_feeds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "922cae82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw_root = Path(\"data/raw\")\n",
+    "processed_root = Path(\"data/processed/rt\")\n",
+    "processed_root.mkdir(parents=True, exist_ok=True)\n",
+    "ingest_all_rt(raw_root, processed_root)\n",
+    "# optional: combine all feeds\n",
+    "union_all_feeds(processed_root, processed_root.parent / \"station_event.parquet\")"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add notebook for batch processing of realtime JSON feeds
- document notebook usage in README

## Testing
- `pytest` *(fails: AttributeError: module 'pyarrow' has no attribute 'parquet')*

------
https://chatgpt.com/codex/tasks/task_e_68665817c108832b973649d9aa45e7aa