### PR TITLE
Add utilities to load realtime data

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,28 @@ Alternatively, the same process can be executed from the command line:
 python -m metro_disruptions_intelligence.etl.ingest_rt data/raw --processed-root data/processed/rt
 ```
 
+Once ingested, the realtime feeds are stored as Parquet files partitioned by
+``year``/``month``/``day`` under ``data/processed/rt``.  Each feed type
+(``alerts``, ``trip_updates`` and ``vehicle_positions``) has its own folder with
+the same partition structure:
+
+```text
+data/processed/rt/alerts/year=2025/month=03/day=06/alerts_2025-06-03-16-49.parquet
+```
+
+To load all partitions for analysis, use the helper
+``load_rt_dataset``:
+
+```python
+from pathlib import Path
+from metro_disruptions_intelligence.processed_reader import load_rt_dataset
+
+processed_rt = Path("data/processed/rt")
+df = load_rt_dataset(processed_rt)
+```
+
+This returns a DataFrame containing all rows across the three feeds with an
+additional ``feed_type`` column indicating the source feed.
 
 ## Contributing
 

--- a/notebooks/02_exploratory_analysis.ipynb
+++ b/notebooks/02_exploratory_analysis.ipynb
@@ -1,0 +1,81 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2d9bafd3",
+   "metadata": {},
+   "source": [
+    "# Exploratory Data Analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9683508",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates how to load all processed real-time GTFS files and perform a basic exploratory analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6de66aaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "from metro_disruptions_intelligence.processed_reader import load_rt_dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea2d273f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_root = Path.cwd()\n",
+    "if not (project_root / \"data\").exists():\n",
+    "    project_root = project_root.parent\n",
+    "processed_rt = project_root / \"data\" / \"processed\" / \"rt\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff655d55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = load_rt_dataset(processed_rt)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4439475b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df[\"feed_type\"].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef4e8bdd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.to_datetime(df[\"snapshot_timestamp\"], unit=\"s\").describe()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/metro_disruptions_intelligence/processed_reader.py
+++ b/src/metro_disruptions_intelligence/processed_reader.py
@@ -1,0 +1,42 @@
+"""Utilities for loading processed GTFS-realtime Parquet files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+FEEDS = ["alerts", "trip_updates", "vehicle_positions"]
+
+
+def load_rt_dataset(processed_root: Path, feeds: Iterable[str] | None = None) -> pd.DataFrame:
+    """Load realtime Parquet partitions into a single DataFrame.
+
+    Parameters
+    ----------
+    processed_root:
+        Directory containing ``alerts``/``trip_updates``/``vehicle_positions`` subfolders.
+    feeds:
+        Optional subset of feed names to load. Defaults to all three feeds.
+
+    Returns:
+    -------
+    pandas.DataFrame
+        Concatenated DataFrame with a ``feed_type`` column.
+    """
+    feeds = list(feeds) if feeds is not None else FEEDS
+    dfs: list[pd.DataFrame] = []
+    for feed in feeds:
+        path = processed_root / feed
+        if not path.exists():
+            continue
+        files = sorted(path.rglob("*.parquet"))
+        if not files:
+            continue
+        df = pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
+        df["feed_type"] = feed
+        dfs.append(df)
+    if dfs:
+        return pd.concat(dfs, ignore_index=True)
+    return pd.DataFrame()

--- a/tests/test_processed_reader.py
+++ b/tests/test_processed_reader.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import pandas as pd
+
+from metro_disruptions_intelligence.etl.ingest_rt import ingest_all_rt
+from metro_disruptions_intelligence.processed_reader import load_rt_dataset
+
+
+def test_load_rt_dataset(tmp_path: Path) -> None:
+    processed_root = tmp_path / "processed" / "rt"
+    ingest_all_rt(Path("sample_data/rt"), processed_root)
+
+    df = load_rt_dataset(processed_root)
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+    assert set(df["feed_type"].unique()) == {"alerts", "trip_updates", "vehicle_positions"}


### PR DESCRIPTION
## Summary
- provide helper `load_rt_dataset` to load partitioned GTFS-RT parquet data
- document processed realtime data usage in README
- add EDA starter notebook
- test the new loader

## Testing
- `pre-commit run --files src/metro_disruptions_intelligence/processed_reader.py tests/test_processed_reader.py README.md notebooks/02_exploratory_analysis.ipynb`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab71ec3f0832b8db90c31963222d3