### PR TITLE
Add output_file option to load_rt_dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,10 @@ from pathlib import Path
 from metro_disruptions_intelligence.processed_reader import load_rt_dataset
 
 processed_rt = Path("data/processed/rt")
-df = load_rt_dataset(processed_rt)
+df = load_rt_dataset(
+    processed_rt,
+    output_file=processed_rt / "all_feeds.parquet",
+)
 ```
 
 This returns a DataFrame containing all rows across the three feeds with an

--- a/src/metro_disruptions_intelligence/processed_reader.py
+++ b/src/metro_disruptions_intelligence/processed_reader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Iterable
 
@@ -10,15 +11,26 @@ import pandas as pd
 FEEDS = ["alerts", "trip_updates", "vehicle_positions"]
 
 
-def load_rt_dataset(processed_root: Path, feeds: Iterable[str] | None = None) -> pd.DataFrame:
+def load_rt_dataset(
+    processed_root: Path,
+    feeds: Iterable[str] | None = None,
+    *,
+    output_file: Path | str | None = None,
+) -> pd.DataFrame:
     """Load realtime Parquet partitions into a single DataFrame.
 
     Parameters
     ----------
     processed_root:
         Directory containing ``alerts``/``trip_updates``/``vehicle_positions`` subfolders.
+        Parquet partitions are discovered recursively using ``Path.rglob`` so
+        the ``year=YYYY/month=MM/day=DD`` layout is handled automatically.
     feeds:
         Optional subset of feed names to load. Defaults to all three feeds.
+    output_file:
+        Optional Parquet file to write the concatenated dataset to. Parent
+        directories are created if necessary. Uses pyarrow with ``snappy``
+        compression.
 
     Returns:
     -------
@@ -37,6 +49,10 @@ def load_rt_dataset(processed_root: Path, feeds: Iterable[str] | None = None) ->
         df = pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
         df["feed_type"] = feed
         dfs.append(df)
-    if dfs:
-        return pd.concat(dfs, ignore_index=True)
-    return pd.DataFrame()
+    result = pd.concat(dfs, ignore_index=True) if dfs else pd.DataFrame()
+    if output_file is not None and not result.empty:
+        out_path = Path(output_file)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        result.to_parquet(out_path, compression="snappy", index=False)
+        logging.info("Wrote combined realtime dataset to %s", out_path)
+    return result

--- a/tests/test_processed_reader.py
+++ b/tests/test_processed_reader.py
@@ -14,3 +14,8 @@ def test_load_rt_dataset(tmp_path: Path) -> None:
     assert isinstance(df, pd.DataFrame)
     assert not df.empty
     assert set(df["feed_type"].unique()) == {"alerts", "trip_updates", "vehicle_positions"}
+
+    output_parquet = processed_root / "all.parquet"
+    df_written = load_rt_dataset(processed_root, output_file=output_parquet)
+    assert output_parquet.exists()
+    pd.testing.assert_frame_equal(df_written, pd.read_parquet(output_parquet))


### PR DESCRIPTION
## Summary
- extend `load_rt_dataset` to optionally write a single concatenated Parquet file
- update README with example using `output_file`
- test new behaviour

## Testing
- `pre-commit run --files src/metro_disruptions_intelligence/processed_reader.py tests/test_processed_reader.py README.md src/metro_disruptions_intelligence.egg-info/PKG-INFO`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac966debc832bbacb84732e0cf608