### PR TITLE
Improve realtime snapshot robustness

### DIFF
--- a/docs/feature_engineering.md
+++ b/docs/feature_engineering.md
@@ -1,0 +1,22 @@
+# Feature engineering workflow
+
+This project builds per-station snapshots for Sydney Metro to detect disruptions using an IsolationForest model. The main steps are:
+
+1. **Realtime ingestion** – Raw GTFS-Realtime JSON files are converted to partitioned Parquet datasets (`trip_updates`, `vehicle_positions`, `alerts`). Each file contains one minute of data with second resolution.
+2. **Route discovery** – On first run we inspect the TripUpdate data to build `route_dir_to_stops`, a mapping from `(route_id, direction_id)` to the ordered list of stops. This allows calculation of upstream and downstream delay windows.
+3. **Graph metrics** – The stop graph derived from `route_dir_to_stops` yields `node_degree` and the `hub_flag` (1 if a stop is in the 90‑th percentile of degree).
+4. **Snapshot feature generation** – For every snapshot minute we call `SnapshotFeatureBuilder.build_snapshot_features`. Input TripUpdates and VehiclePositions are filtered to tolerate up to 60 s and 30 s of latency respectively. Forecasts more than two hours in the future are ignored. Per (stop, direction) we select the first TripUpdate whose arrival time is at or after the snapshot timestamp.
+5. **Sanity checks and state management** – The builder caps headways at one hour, resets rolling state after 03:00 local on service day changes and limits vehicle data freshness to 24 h. Invalid headways or negative intervals are discarded.
+6. **Feature computation** – The following columns are produced:
+   - `arrival_delay_t`, `departure_delay_t`
+   - `headway_t`, `rel_headway_t`, `dwell_delta_t`
+   - `delay_arrival_grad_t`, `delay_departure_grad_t`
+   - `upstream_delay_mean_2`, `downstream_delay_max_2`
+   - rolling statistics: `delay_mean_5`, `delay_std_5`, `delay_mean_15`, `headway_p90_60`
+   - time features: `sin_hour`, `cos_hour`, `day_type`
+   - network metrics: `node_degree`, `hub_flag`
+   - presence indicators: `is_train_present`, `data_fresh_secs`
+   A `route_id` column is included only when multiple routes appear in the snapshot.
+7. **Output** – The resulting DataFrame is indexed by `(stop_id, direction_id)` and written to `data/stations_features_time_series/year=YYYY/month=MM/day=DD/stations_feats_YYYY-DD-MM-HH-MM.parquet`.
+
+These features are then fed to an IsolationForest model to flag anomalies in real time.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ nav:
   - Home: index.md
   - Installation: installation.md
   - Realtime ingestion: realtime_ingestion.md
+  - Feature engineering: feature_engineering.md
   - Examples: [] # this will be filled in automatically to include reference to all the notebooks
   - Contributing: contributing.md
   - Changelog: CHANGELOG.md

--- a/src/metro_disruptions_intelligence/__init__.py
+++ b/src/metro_disruptions_intelligence/__init__.py
@@ -1,3 +1,14 @@
 """Top-level module for metro_disruptions_intelligence."""
 
+from .features import SnapshotFeatureBuilder
+from .utils_gtfsrt import is_new_service_day, make_fake_tu, make_fake_vp
+
 __version__ = "0.1.0.dev0"
+
+__all__ = [
+    "SnapshotFeatureBuilder",
+    "is_new_service_day",
+    "make_fake_tu",
+    "make_fake_vp",
+    "__version__",
+]

--- a/src/metro_disruptions_intelligence/utils_gtfsrt.py
+++ b/src/metro_disruptions_intelligence/utils_gtfsrt.py
@@ -1,0 +1,57 @@
+"""Helpers for GTFS-Realtime unit tests and time conversions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pandas as pd
+import pytz
+
+_TZ_SYDNEY = pytz.timezone("Australia/Sydney")
+
+
+def sydney_time(ts: int) -> datetime:
+    """Convert epoch seconds to Sydney local time."""
+    return datetime.fromtimestamp(ts, _TZ_SYDNEY)
+
+
+def is_new_service_day(prev_ts: int | None, cur_ts: int, reset_at_hour: int) -> bool:
+    """Return ``True`` if ``cur_ts`` starts a new service day."""
+    if prev_ts is None:
+        return False
+    prev = sydney_time(prev_ts)
+    cur = sydney_time(cur_ts)
+    return (cur.date() != prev.date()) and (cur.hour >= reset_at_hour)
+
+
+def make_fake_tu(
+    snapshot_ts: int,
+    arrival_time: int,
+    *,
+    stop_id: str = "STOP",
+    direction_id: int = 0,
+    trip_id: str = "T1",
+    route_id: str = "R",
+) -> pd.DataFrame:
+    """Create a minimal TripUpdate DataFrame for testing."""
+    return pd.DataFrame({
+        "snapshot_timestamp": [snapshot_ts],
+        "route_id": [route_id],
+        "direction_id": [direction_id],
+        "stop_id": [stop_id],
+        "arrival_time": [arrival_time],
+        "departure_time": [arrival_time + 30],
+        "arrival_delay": [0.0],
+        "departure_delay": [0.0],
+        "trip_id": [trip_id],
+        "stop_sequence": [1],
+    })
+
+
+def make_fake_vp(snapshot_ts: int, *, stop_id: str = "STOP", direction_id: int = 0) -> pd.DataFrame:
+    """Create a minimal VehiclePosition DataFrame for testing."""
+    return pd.DataFrame({
+        "snapshot_timestamp": [snapshot_ts],
+        "stop_id": [stop_id],
+        "direction_id": [direction_id],
+    })

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from metro_disruptions_intelligence.features import SnapshotFeatureBuilder
+from metro_disruptions_intelligence.utils_gtfsrt import make_fake_tu, make_fake_vp
 
 
 def _route_dir_to_stops(df: pd.DataFrame) -> dict:
@@ -20,3 +21,14 @@ def test_build_snapshot_features() -> None:
     feats = builder.build_snapshot_features(trip_now, veh_now, ts)
     assert not feats.empty
     assert isinstance(feats.index, pd.MultiIndex)
+
+
+def test_headway_bounds() -> None:
+    ts = 1_000
+    tu1 = make_fake_tu(ts - 30, ts + 10)
+    tu2 = make_fake_tu(ts, ts + 70)
+    vp = make_fake_vp(ts, stop_id="STOP")
+    builder = SnapshotFeatureBuilder({("R", 0): ["STOP"]})
+    builder.build_snapshot_features(tu1, vp, ts - 30)
+    feats = builder.build_snapshot_features(tu2, vp, ts)
+    assert feats["headway_t"].dropna().le(3600).all()

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -1,0 +1,22 @@
+from metro_disruptions_intelligence.features import SnapshotFeatureBuilder
+from metro_disruptions_intelligence.utils_gtfsrt import make_fake_tu, make_fake_vp
+
+ROUTE_MAP = {("R", 0): ["STOP"]}
+
+
+def test_tolerates_60s_tu_lag():
+    ts = 1_000
+    tu = make_fake_tu(ts - 40, ts + 50)
+    vp = make_fake_vp(ts, stop_id="STOP")
+    builder = SnapshotFeatureBuilder(ROUTE_MAP)
+    feats = builder.build_snapshot_features(tu, vp, ts)
+    assert not feats.empty
+
+
+def test_discards_90s_tu_lag():
+    ts = 1_000
+    tu = make_fake_tu(ts - 90, ts + 50)
+    vp = make_fake_vp(ts, stop_id="STOP")
+    builder = SnapshotFeatureBuilder(ROUTE_MAP)
+    feats = builder.build_snapshot_features(tu, vp, ts)
+    assert feats.empty


### PR DESCRIPTION
## Summary
- guard against runaway headways and stale vehicle data
- accept slight GTFS-RT latency
- expose GTFS‑RT helper utilities for tests
- add latency and headway unit tests
- document the feature engineering workflow

## Testing
- `ruff check src/metro_disruptions_intelligence/features.py src/metro_disruptions_intelligence/utils_gtfsrt.py tests/test_features.py tests/test_latency.py src/metro_disruptions_intelligence/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f9c2165c0832bbab737f89b9eca53