### PR TITLE
Fix duplicate-trip churn, emit gap rows, clip delays, add local_dt

### DIFF
--- a/src/metro_disruptions_intelligence/utils_gtfsrt.py
+++ b/src/metro_disruptions_intelligence/utils_gtfsrt.py
@@ -3,11 +3,28 @@
 from __future__ import annotations
 
 from datetime import datetime
+from types import SimpleNamespace
 
 import pandas as pd
 import pytz
 
 _TZ_SYDNEY = pytz.timezone("Australia/Sydney")
+
+# Constants shared between features and tests
+DELAY_CAP = 300
+LAG_TU_SECS = 60
+LAG_VP_SECS = 30
+MAX_FUTURE_SECS = 2 * 60 * 60
+MAX_HEADWAY_SECS = 60 * 60
+
+# Exported container of constants
+CONSTANTS = SimpleNamespace(
+    DELAY_CAP=DELAY_CAP,
+    LAG_TU_SECS=LAG_TU_SECS,
+    LAG_VP_SECS=LAG_VP_SECS,
+    MAX_FUTURE_SECS=MAX_FUTURE_SECS,
+    MAX_HEADWAY_SECS=MAX_HEADWAY_SECS,
+)
 
 
 def sydney_time(ts: int) -> datetime:

--- a/tests/test_duplicate_trip.py
+++ b/tests/test_duplicate_trip.py
@@ -1,0 +1,43 @@
+import time
+
+import pandas as pd
+
+from metro_disruptions_intelligence.features import SnapshotFeatureBuilder
+from metro_disruptions_intelligence.utils_gtfsrt import make_fake_vp
+
+ROUTE_DIR_TO_STOPS_DUMMY = {("SMNW_M1", 0): [2154263]}
+
+
+def make_snapshot(ts, arrival_offset):
+    return pd.DataFrame({
+        "snapshot_timestamp": [ts],
+        "trip_id": ["T1"],
+        "stop_id": [2154263],
+        "direction_id": [0],
+        "arrival_time": [ts + arrival_offset],
+        "departure_time": [ts + arrival_offset + 30],
+        "arrival_delay": [20],
+        "departure_delay": [25],
+        "route_id": ["SMNW_M1"],
+        "stop_sequence": [10],
+    })
+
+
+def test_duplicate_trip_emits_one_real_row():
+    builder = SnapshotFeatureBuilder(ROUTE_DIR_TO_STOPS_DUMMY)
+    base = int(time.time())
+    tu0 = make_snapshot(base - 60, 120).assign(trip_id="T0")
+    tu1 = make_snapshot(base, 240)
+    tu2 = make_snapshot(base + 60, 180)
+    tu3 = make_snapshot(base + 120, 120)
+    vp = make_fake_vp(base, stop_id=2154263, direction_id=0)
+
+    builder.build_snapshot_features(tu0, vp, base - 60)
+
+    f1 = builder.build_snapshot_features(tu1, vp, base)
+    f2 = builder.build_snapshot_features(tu2, vp, base + 60)
+    f3 = builder.build_snapshot_features(tu3, vp, base + 120)
+
+    assert f1["headway_t"].notna().any()
+    assert f2["headway_t"].isna().all()
+    assert f3["headway_t"].isna().all()

--- a/tests/test_partial_gap.py
+++ b/tests/test_partial_gap.py
@@ -1,0 +1,40 @@
+import time
+
+import pandas as pd
+
+from metro_disruptions_intelligence.features import SnapshotFeatureBuilder
+from metro_disruptions_intelligence.utils_gtfsrt import make_fake_vp
+
+ROUTE_DIR_TO_STOPS_DUMMY = {("SMNW_M1", 0): [2154263, 2113341]}
+
+
+def make_tu_row(ts, stop_id, trip_id="T1"):
+    return {
+        "snapshot_timestamp": ts,
+        "trip_id": trip_id,
+        "stop_id": stop_id,
+        "direction_id": 0,
+        "arrival_time": ts + 180,
+        "departure_time": ts + 210,
+        "arrival_delay": 30,
+        "departure_delay": 35,
+        "route_id": "SMNW_M1",
+        "stop_sequence": 5,
+    }
+
+
+def test_partial_gap_row():
+    builder = SnapshotFeatureBuilder(ROUTE_DIR_TO_STOPS_DUMMY)
+    ts = int(time.time())
+
+    tu = pd.DataFrame([make_tu_row(ts, 2154263), make_tu_row(ts, 2113341)])
+    vp = make_fake_vp(ts, stop_id=2154263, direction_id=0)
+    builder.build_snapshot_features(tu, vp, ts)
+
+    tu2 = pd.DataFrame([make_tu_row(ts + 60, 2154263, trip_id="T2")])
+    feats = builder.build_snapshot_features(tu2, vp, ts + 60)
+
+    a = feats.loc[(2154263, 0)]
+    b = feats.loc[(2113341, 0)]
+    assert not pd.isna(a["arrival_delay_t"])
+    assert pd.isna(b["arrival_delay_t"])


### PR DESCRIPTION
## Summary
- deduplicate repeated trips in feature builder
- emit gap rows when updates missing
- clip delays to 5 minutes and expose Sydney timestamp
- share GTFS-RT constants via utils
- log data stats and add duplicate-trip regression test
- emit per-stop gap rows and drop zero fall-backs
- new partial-gap scenario test

## Testing
- `pre-commit run --files src/metro_disruptions_intelligence/features.py tests/test_partial_gap.py tests/test_duplicate_trip.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fdaf25b34832bbfea881323611118