### PR TITLE
Fix snapshot filename parsing

### DIFF
--- a/tests/test_compose_path_partitions.py
+++ b/tests/test_compose_path_partitions.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from pathlib import Path
+
+import pytz
+
+from metro_disruptions_intelligence.processed_reader import compose_path
+
+
+def test_compose_path_partition(tmp_path: Path) -> None:
+    base = tmp_path / "trip_updates" / "year=2025" / "month=05" / "day=22"
+    base.mkdir(parents=True)
+    target = base / "trip_updates_2025-22-05-11-55.parquet"
+    target.touch()
+    ts = int(datetime(2025, 5, 22, 11, 55, tzinfo=pytz.UTC).timestamp())
+    assert compose_path(ts, tmp_path, "trip_updates") == target

--- a/tests/test_snapshot_discovery.py
+++ b/tests/test_snapshot_discovery.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from metro_disruptions_intelligence.processed_reader import (
+    compose_path,
+    discover_all_snapshot_minutes,
+)
+
+
+def _touch(p: Path) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.touch()
+
+
+def test_discover_both_filename_formats(tmp_path: Path) -> None:
+    root = tmp_path / "rt"
+    # day-month format
+    p1 = (
+        root
+        / "trip_updates"
+        / "year=2025"
+        / "month=03"
+        / "day=06"
+        / "trip_updates_2025-06-03-11-56.parquet"
+    )
+    # month-day format
+    p2 = (
+        root
+        / "trip_updates"
+        / "year=2025"
+        / "month=05"
+        / "day=22"
+        / "trip_updates_2025-05-22-11-55.parquet"
+    )
+    _touch(p1)
+    _touch(p2)
+
+    minutes = discover_all_snapshot_minutes(root)
+    assert len(minutes) == 2
+
+    for ts in minutes:
+        path = compose_path(ts, root, "trip_updates")
+        assert path.exists()


### PR DESCRIPTION
## Summary
- support both day-first and month-first naming for snapshot Parquets
- search both formats when building filenames
- add regression test for snapshot discovery
- add regression test ensuring compose_path returns the existing file in the correct partition

## Testing
- `pre-commit run --files tests/test_compose_path_partitions.py src/metro_disruptions_intelligence/processed_reader.py tests/test_snapshot_discovery.py tests/test_date_format.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68717e9bd350832b965ffb4938b36fea