### PR TITLE
Add route map builder and update notebook

### DIFF
--- a/notebooks/03_generate_features_and_eda.ipynb
+++ b/notebooks/03_generate_features_and_eda.ipynb
@@ -32,7 +32,7 @@
     "import pandas as pd\n",
     "import pytz\n",
     "\n",
-    "from metro_disruptions_intelligence.features import SnapshotFeatureBuilder\n",
+    "from metro_disruptions_intelligence.features import SnapshotFeatureBuilder, build_route_map\n",
     "from metro_disruptions_intelligence.processed_reader import load_rt_dataset"
    ]
   },
@@ -94,6 +94,7 @@
     "import pytz, os\n",
     "import pandas as pd\n",
     "\n",
+    "from metro_disruptions_intelligence.features import build_route_map\n",
     "# ─────────────────────────────────────────────────────────────────────────────\n",
     "# internal helpers\n",
     "# ─────────────────────────────────────────────────────────────────────────────\n",
@@ -146,25 +147,7 @@
     "\n",
     "    path_d = base / _fname(dt, feed, day_first=True)   # YYYY-DD-MM\n",
     "    return path_d   # even if it doesn’t exist – caller will check\n",
-    "\n",
-    "\n",
-    "def build_route_map(root: Path) -> dict:\n",
-    "    \"\"\"\n",
-    "    Build { (route_id, direction_id): [ordered stop_ids] } from the first\n",
-    "    TripUpdate snapshot we can find.\n",
-    "    \"\"\"\n",
-    "    first = next((root / \"trip_updates\").rglob(\"trip_updates_*.parquet\"), None)\n",
-    "    if first is None:\n",
-    "        raise FileNotFoundError(\"No trip_updates*.parquet snapshots found\")\n",
-    "\n",
-    "    df = pd.read_parquet(first)\n",
-    "    tu = (df[[\"route_id\", \"direction_id\", \"stop_id\", \"stop_sequence\"]]\n",
-    "          .drop_duplicates()\n",
-    "          .sort_values([\"route_id\", \"direction_id\", \"stop_sequence\"]))\n",
-    "\n",
-    "    return (tu.groupby([\"route_id\", \"direction_id\"])[\"stop_id\"]\n",
-    "              .apply(list)\n",
-    "              .to_dict())\n"
+    "\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- add `build_route_map` utility for assembling stops across all trip update parquet files
- use the new helper in the feature generation notebook
- confirm stop `2000461` is found and feature generation proceeds without key errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872b0e422a4832bb757b2ef07ba8d2e