### PR TITLE
Fix realtime date parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ the same partition structure:
 data/processed/rt/alerts/year=2025/month=03/day=06/alerts_2025-06-03-16-49.parquet
 ```
 
+Filenames use the day‑first convention `YYYY-DD-MM-HH-MM`.
+
 To load all partitions for analysis, use the helper
 ``load_rt_dataset``:
 

--- a/docs/feature_engineering.md
+++ b/docs/feature_engineering.md
@@ -18,5 +18,6 @@ This project builds per-station snapshots for Sydney Metro to detect disruptions
    - presence indicators: `is_train_present`, `data_fresh_secs`
    A `route_id` column is included only when multiple routes appear in the snapshot.
 7. **Output** – The resulting DataFrame is indexed by `(stop_id, direction_id)` and written to `data/stations_features_time_series/year=YYYY/month=MM/day=DD/stations_feats_YYYY-DD-MM-HH-MM.parquet`.
+   Filenames follow the `YYYY-DD-MM-HH-MM` convention.
 
 These features are then fed to an IsolationForest model to flag anomalies in real time.

--- a/src/metro_disruptions_intelligence/processed_reader.py
+++ b/src/metro_disruptions_intelligence/processed_reader.py
@@ -95,12 +95,9 @@ def discover_all_snapshot_minutes(root: Path) -> list[int]:
 def compose_path(ts: int, root: Path, feed: str) -> Path:
     """Construct Parquet path for ``feed`` at ``ts``.
 
-    Returns the existing path if either date format is present.
+    Returns the existing path for the configured day-first filename convention.
     """
     dt = datetime.fromtimestamp(ts, tz=_TZ_LONDON)
 
     base = root / feed / f"year={dt.year:04d}" / f"month={dt.month:02d}" / f"day={dt.day:02d}"
-    path_d = base / _fname(dt, feed, day_first=True)
-    if path_d.exists():
-        return path_d
-    return base / _fname(dt, feed, day_first=False)
+    return base / _fname(dt, feed)

--- a/src/metro_disruptions_intelligence/utils_gtfsrt.py
+++ b/src/metro_disruptions_intelligence/utils_gtfsrt.py
@@ -11,15 +11,13 @@ import pytz
 _TZ_SYDNEY = pytz.timezone("Australia/Sydney")
 _TZ_LONDON = pytz.timezone("Europe/London")
 
-_PATTERNS = (
-    "%Y-%d-%m-%H-%M",  # day-month
-    "%Y-%m-%d-%H-%M",  # month-day
-)
+# Filenames use the day-first convention: YYYY-DD-MM-HH-MM
+_PATTERNS = ("%Y-%d-%m-%H-%M",)
 
 # Constants shared between features and tests
 DELAY_CAP = 300
-LAG_TU_SECS = 180   # trip_updates can now be up to 3 minutes behind
-LAG_VP_SECS = 60    # vehicle_positions can now be up to 1 minute behind
+LAG_TU_SECS = 180  # trip_updates can now be up to 3 minutes behind
+LAG_VP_SECS = 60  # vehicle_positions can now be up to 1 minute behind
 MAX_FUTURE_SECS = 2 * 60 * 60
 MAX_HEADWAY_SECS = 60 * 60
 
@@ -80,9 +78,11 @@ def make_fake_vp(snapshot_ts: int, *, stop_id: str = "STOP", direction_id: int =
     })
 
 
-def _fname(dt: datetime, feed: str, day_first: bool) -> str:
+def _fname(dt: datetime, feed: str, day_first: bool = True) -> str:
     """Return Parquet filename for ``feed`` at ``dt`` in London time."""
-    pat = "%Y-%d-%m-%H-%M" if day_first else "%Y-%m-%d-%H-%M"
+    # ``day_first`` is kept for backward compatibility but ignored; filenames are
+    # always produced using the day-first convention.
+    pat = "%Y-%d-%m-%H-%M"
     local = dt.astimezone(_TZ_LONDON)
     return f"{feed}_{local.strftime(pat)}.parquet"
 

--- a/tests/test_date_format.py
+++ b/tests/test_date_format.py
@@ -6,16 +6,15 @@ from metro_disruptions_intelligence.processed_reader import (
 )
 
 
-def test_discover_handles_mm_dd(tmp_path: Path) -> None:
+def test_discover_handles_dd_mm(tmp_path: Path) -> None:
     root = tmp_path / "rt"
-    p = root / "trip_updates" / "year=2025" / "month=05" / "day=22"
+    p = root / "trip_updates" / "year=2025" / "month=03" / "day=06"
     p.mkdir(parents=True, exist_ok=True)
-    (p / "trip_updates_2025-05-22-11-56.parquet").touch()
+    (p / "trip_updates_2025-06-03-11-56.parquet").touch()
 
     minutes = discover_all_snapshot_minutes(root)
-    assert minutes, "MM-DD file should be discovered"
+    assert minutes
 
     ts = minutes[0]
-    # round trip via compose_path
     path = compose_path(ts, root, "trip_updates")
     assert path.exists()

--- a/tests/test_snapshot_discovery.py
+++ b/tests/test_snapshot_discovery.py
@@ -11,10 +11,9 @@ def _touch(p: Path) -> None:
     p.touch()
 
 
-def test_discover_both_filename_formats(tmp_path: Path) -> None:
+def test_discover_single_filename_format(tmp_path: Path) -> None:
     root = tmp_path / "rt"
-    # day-month format
-    p1 = (
+    p = (
         root
         / "trip_updates"
         / "year=2025"
@@ -22,20 +21,10 @@ def test_discover_both_filename_formats(tmp_path: Path) -> None:
         / "day=06"
         / "trip_updates_2025-06-03-11-56.parquet"
     )
-    # month-day format
-    p2 = (
-        root
-        / "trip_updates"
-        / "year=2025"
-        / "month=05"
-        / "day=22"
-        / "trip_updates_2025-05-22-11-55.parquet"
-    )
-    _touch(p1)
-    _touch(p2)
+    _touch(p)
 
     minutes = discover_all_snapshot_minutes(root)
-    assert len(minutes) == 2
+    assert len(minutes) == 1
 
     for ts in minutes:
         path = compose_path(ts, root, "trip_updates")


### PR DESCRIPTION
## Summary
- unify naming convention to year-day-month-hour-minute
- update realtime ingestion parser and CLI helpers
- simplify processed reader to expect a single format
- document new date conventions
- adjust tests for single date format

## Testing
- `pre-commit run --files README.md docs/feature_engineering.md src/metro_disruptions_intelligence/etl/ingest_rt.py src/metro_disruptions_intelligence/processed_reader.py src/metro_disruptions_intelligence/utils_gtfsrt.py tests/test_date_format.py tests/test_snapshot_discovery.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687592b9ec1c832baafed0abf96dae97