### PR TITLE
Update ingest_rt help

### DIFF
--- a/src/metro_disruptions_intelligence/etl/ingest_rt.py
+++ b/src/metro_disruptions_intelligence/etl/ingest_rt.py
@@ -165,10 +165,19 @@ def _parse_args(argv: list[str] | None = None) -> IngestRTConfig:
         "--start-time",
         type=str,
         default=None,
-        help="Only ingest files with timestamp >= START_TIME (YYYY-DD-MM or YYYY_DD_MM_HH_MM_SS)",
+        help=(
+            "Only ingest files with timestamp >= START_TIME. "
+            "Format: YYYY-DD-MM[-HH-MM-SS]; underscores are also accepted."
+        ),
     )
     parser.add_argument(
-        "--end-time", type=str, default=None, help="Only ingest files with timestamp <= END_TIME"
+        "--end-time",
+        type=str,
+        default=None,
+        help=(
+            "Only ingest files with timestamp <= END_TIME. "
+            "Format: YYYY-DD-MM[-HH-MM-SS]; underscores are also accepted."
+        ),
     )
     args = parser.parse_args(argv)
     cfg_dict = vars(args)


### PR DESCRIPTION
## Summary
- update CLI help strings for start and end times

## Testing
- `pre-commit run --files src/metro_disruptions_intelligence/etl/ingest_rt.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876705c7000832ba22b41514ea2a769