### PR TITLE
Add generate-features CLI command

### DIFF
--- a/docs/feature_engineering.md
+++ b/docs/feature_engineering.md
@@ -21,3 +21,18 @@ This project builds per-station snapshots for Sydney Metro to detect disruptions
    Filenames follow the `YYYY-DD-MM-HH-MM` convention.
 
 These features are then fed to an IsolationForest model to flag anomalies in real time.
+
+## Command line usage
+
+The ``generate-features`` command automates route discovery and snapshot
+processing. Given a directory of processed GTFS-Realtime Parquet files it writes
+per-minute feature files to ``data/stations_features_time_series`` by default.
+
+```bash
+metro_disruptions_intelligence generate-features data/processed/rt \
+  --output-root data/stations_features_time_series \
+  --start-time 2025-06-03T10:00:00 --end-time 2025-06-03T10:30:00
+```
+
+The ``--start-time`` and ``--end-time`` options accept the same formats as the
+``ingest-rt`` command and allow selecting a date range to process.

--- a/src/metro_disruptions_intelligence/cli.py
+++ b/src/metro_disruptions_intelligence/cli.py
@@ -1,11 +1,16 @@
 """Command line entry points for :mod:`metro_disruptions_intelligence`."""
 
+from datetime import datetime
 from pathlib import Path
 
 import click
+import pandas as pd
+import pytz
 
-from .etl.ingest_rt import ingest_all_rt, union_all_feeds, _parse_cli_time
+from .etl.ingest_rt import _parse_cli_time, ingest_all_rt, union_all_feeds
 from .etl.static_ingest import ingest_static_gtfs
+from .features import SnapshotFeatureBuilder, build_route_map, write_features
+from .processed_reader import compose_path, discover_all_snapshot_minutes
 
 
 @click.group()
@@ -67,3 +72,71 @@ def ingest_rt_cmd(
     if union:
         output_parquet = processed_root.parent / "station_event.parquet"
         union_all_feeds(processed_root, output_parquet)
+
+
+@cli.command("generate-features")
+@click.argument("processed_root", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--output-root",
+    type=click.Path(path_type=Path),
+    default=Path("data/stations_features_time_series"),
+    show_default=True,
+    help="Directory for feature Parquet output",
+)
+@click.option(
+    "--start-time",
+    type=str,
+    default=None,
+    help="Process snapshots on or after this time",
+)
+@click.option(
+    "--end-time",
+    type=str,
+    default=None,
+    help="Process snapshots up to this time",
+)
+def generate_features_cmd(
+    processed_root: Path,
+    output_root: Path,
+    start_time: str | None,
+    end_time: str | None,
+) -> None:
+    """Generate per-minute feature Parquet files from processed realtime data."""
+    start_dt = _parse_cli_time(start_time) if start_time else None
+    end_dt = _parse_cli_time(end_time) if end_time else None
+
+    route_map = build_route_map(processed_root)
+    builder = SnapshotFeatureBuilder(route_map)
+    minutes = discover_all_snapshot_minutes(processed_root)
+
+    if start_dt:
+        start_ts = int(start_dt.timestamp())
+        minutes = [m for m in minutes if m >= start_ts]
+    if end_dt:
+        end_ts = int(end_dt.timestamp())
+        minutes = [m for m in minutes if m <= end_ts]
+
+    for ts in minutes:
+        tu_file = compose_path(ts, processed_root, "trip_updates")
+        vp_file = compose_path(ts, processed_root, "vehicle_positions")
+        if not tu_file.exists() or not vp_file.exists():
+            continue
+
+        trip_now = pd.read_parquet(tu_file)
+        veh_now = pd.read_parquet(vp_file)
+        feats = builder.build_snapshot_features(trip_now, veh_now, ts)
+        if feats.empty:
+            continue
+
+        feats = feats.reset_index()
+        feats["snapshot_timestamp"] = ts
+
+        dt = datetime.fromtimestamp(ts, tz=pytz.UTC)
+        out_dir = (
+            output_root
+            / f"year={dt.year:04d}"
+            / f"month={dt.month:02d}"
+            / f"day={dt.day:02d}"
+        )
+        out_file = out_dir / f"stations_feats_{dt:%Y-%d-%m-%H-%M}.parquet"
+        write_features(feats, out_file)


### PR DESCRIPTION
## Summary
- add new generate-features command to cli.py
- write snapshot features to parquet using SnapshotFeatureBuilder
- document the command in feature_engineering docs

## Testing
- `ruff check src/metro_disruptions_intelligence/cli.py`
- `pytest -q` *(fails: FileNotFoundError: No such file or directory: 'sample_data/rt_parquet/...')*

------
https://chatgpt.com/codex/tasks/task_e_687683cb41c0832b8f10a8ee04f9c3ca