### PR TITLE
Handle empty Trip Updates

### DIFF
--- a/src/metro_disruptions_intelligence/cli.py
+++ b/src/metro_disruptions_intelligence/cli.py
@@ -29,9 +29,7 @@ def cli() -> None:
     show_default=True,
     help="Directory to store processed Parquet and optional DuckDB",
 )
-@click.option(
-    "--persist-duckdb", is_flag=True, help="Persist the intermediate DuckDB DB"
-)
+@click.option("--persist-duckdb", is_flag=True, help="Persist the intermediate DuckDB DB")
 def ingest_static_cmd(gtfs_dir: Path, output_dir: Path, persist_duckdb: bool) -> None:
     """Ingest static GTFS files into Parquet tables."""
     ingest_static_gtfs(gtfs_dir, output_dir, persist_duckdb)
@@ -46,21 +44,11 @@ def ingest_static_cmd(gtfs_dir: Path, output_dir: Path, persist_duckdb: bool) ->
     show_default=True,
     help="Destination directory for partitioned Parquet",
 )
-@click.option(
-    "--union", is_flag=True, help="Create combined station_event.parquet file"
-)
-@click.option(
-    "--start-time", type=str, default=None, help="Process files starting from this time"
-)
-@click.option(
-    "--end-time", type=str, default=None, help="Process files up to this time"
-)
+@click.option("--union", is_flag=True, help="Create combined station_event.parquet file")
+@click.option("--start-time", type=str, default=None, help="Process files starting from this time")
+@click.option("--end-time", type=str, default=None, help="Process files up to this time")
 def ingest_rt_cmd(
-    raw_root: Path,
-    processed_root: Path,
-    union: bool,
-    start_time: str | None,
-    end_time: str | None,
+    raw_root: Path, processed_root: Path, union: bool, start_time: str | None, end_time: str | None
 ) -> None:
     """Ingest realtime JSON feeds into Parquet tables."""
     ingest_all_rt(
@@ -84,22 +72,11 @@ def ingest_rt_cmd(
     help="Directory for feature Parquet output",
 )
 @click.option(
-    "--start-time",
-    type=str,
-    default=None,
-    help="Process snapshots on or after this time",
+    "--start-time", type=str, default=None, help="Process snapshots on or after this time"
 )
-@click.option(
-    "--end-time",
-    type=str,
-    default=None,
-    help="Process snapshots up to this time",
-)
+@click.option("--end-time", type=str, default=None, help="Process snapshots up to this time")
 def generate_features_cmd(
-    processed_root: Path,
-    output_root: Path,
-    start_time: str | None,
-    end_time: str | None,
+    processed_root: Path, output_root: Path, start_time: str | None, end_time: str | None
 ) -> None:
     """Generate per-minute feature Parquet files from processed realtime data."""
     start_dt = _parse_cli_time(start_time) if start_time else None
@@ -125,18 +102,13 @@ def generate_features_cmd(
         trip_now = pd.read_parquet(tu_file)
         veh_now = pd.read_parquet(vp_file)
         feats = builder.build_snapshot_features(trip_now, veh_now, ts)
-        if feats.empty:
-            continue
 
         feats = feats.reset_index()
         feats["snapshot_timestamp"] = ts
 
         dt = datetime.fromtimestamp(ts, tz=pytz.UTC)
         out_dir = (
-            output_root
-            / f"year={dt.year:04d}"
-            / f"month={dt.month:02d}"
-            / f"day={dt.day:02d}"
+            output_root / f"year={dt.year:04d}" / f"month={dt.month:02d}" / f"day={dt.day:02d}"
         )
         out_file = out_dir / f"stations_feats_{dt:%Y-%d-%m-%H-%M}.parquet"
         write_features(feats, out_file)

--- a/src/metro_disruptions_intelligence/features.py
+++ b/src/metro_disruptions_intelligence/features.py
@@ -130,7 +130,23 @@ class SnapshotFeatureBuilder:
         )
 
         if trip_updates.empty:
-            return pd.DataFrame()
+            empty_rows = [
+                self._empty_feature_row(
+                    pd.Series({
+                        "snapshot_timestamp": ts,
+                        "route_id": None,
+                        "sin_hour": sin_hour,
+                        "cos_hour": cos_hour,
+                        "day_type": day_type,
+                        "local_dt": local_dt,
+                    }),
+                    key,
+                )
+                for key in self._state
+            ]
+            df = pd.DataFrame(empty_rows)
+            df.set_index(["stop_id", "direction_id"], inplace=True)
+            return df
 
         missing = set(zip(trip_updates["stop_id"], trip_updates["direction_id"])) - set(
             self._state.keys()

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -51,3 +51,29 @@ def test_snapshot_non_zero_delay() -> None:
     feats = builder.build_snapshot_features(tu, vp, ts).reset_index()
     assert not feats.empty
     assert (feats["arrival_delay_t"].abs() > 0).any()
+
+
+def test_empty_trip_updates_returns_gap_rows() -> None:
+    ts = 1000
+    route_map = {("R", 0): ["A", "B"]}
+    builder = SnapshotFeatureBuilder(route_map)
+    tu = pd.DataFrame(
+        columns=[
+            "snapshot_timestamp",
+            "route_id",
+            "direction_id",
+            "stop_id",
+            "arrival_time",
+            "departure_time",
+            "arrival_delay",
+            "departure_delay",
+            "trip_id",
+            "stop_sequence",
+        ]
+    )
+    vp = pd.DataFrame(columns=["snapshot_timestamp", "stop_id", "direction_id"])
+
+    feats = builder.build_snapshot_features(tu, vp, ts)
+    assert not feats.empty
+    assert set(feats.index) == {("A", 0), ("B", 0)}
+    assert feats["arrival_delay_t"].isna().all()


### PR DESCRIPTION
## Summary
- fill gap rows when no Trip Updates are present
- always write feature parquet in CLI
- test gap row generation

## Testing
- `ruff check tests/test_features.py src/metro_disruptions_intelligence/features.py src/metro_disruptions_intelligence/cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68768b41a4ac832b81a7e6f0cd239087