### PR TITLE
Log warning when vehicle_positions snapshot is empty

### DIFF
--- a/src/metro_disruptions_intelligence/cli.py
+++ b/src/metro_disruptions_intelligence/cli.py
@@ -108,6 +108,8 @@ def generate_features_cmd(
 
         trip_now = pd.read_parquet(tu_file)
         veh_now = pd.read_parquet(vp_file)
+        if veh_now.empty:
+            logger.warning("vehicle_positions file %s contains no rows", vp_file)
         feats = builder.build_snapshot_features(trip_now, veh_now, ts)
 
         feats = feats.reset_index()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,15 @@
 """Tests for :mod:`metro_disruptions_intelligence.cli`."""
 
-from click.testing import CliRunner
-import pytest
+import logging
 from pathlib import Path
 
+import pandas as pd
+import pytest
+from click.testing import CliRunner
+
 from metro_disruptions_intelligence import cli
+from metro_disruptions_intelligence.processed_reader import compose_path
+from metro_disruptions_intelligence.utils_gtfsrt import make_fake_tu
 
 
 def test_cli_group_help():
@@ -34,3 +39,28 @@ def test_cli_ingest_commands(tmp_path):
     )
     assert result.exit_code == 0
     assert (tmp_path / "station_event.parquet").exists()
+
+
+def test_generate_features_warn_empty_vehicle_positions(tmp_path, caplog):
+    runner = CliRunner()
+
+    ts = 1_000
+    processed_root = tmp_path / "rt"
+    tu_file = compose_path(ts, processed_root, "trip_updates")
+    vp_file = compose_path(ts, processed_root, "vehicle_positions")
+    tu_file.parent.mkdir(parents=True, exist_ok=True)
+    vp_file.parent.mkdir(parents=True, exist_ok=True)
+
+    make_fake_tu(ts, ts + 60).to_parquet(tu_file, index=False)
+    pd.DataFrame(columns=["snapshot_timestamp", "stop_id", "direction_id"]).to_parquet(
+        vp_file, index=False
+    )
+
+    output_root = tmp_path / "out"
+    with caplog.at_level(logging.WARNING):
+        result = runner.invoke(
+            cli.cli, ["generate-features", str(processed_root), "--output-root", str(output_root)]
+        )
+    assert result.exit_code == 0
+    assert f"vehicle_positions file {vp_file} contains no rows" in caplog.text
+    assert list(output_root.rglob("stations_feats_*.parquet"))


### PR DESCRIPTION
## Summary
- emit a warning if a vehicle_positions parquet snapshot contains no rows
- test that an empty vehicle_positions file logs the warning when generating features

## Testing
- `pre-commit run --files src/metro_disruptions_intelligence/cli.py tests/test_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876955bad20832b839ce28dfe6310c2