### PR TITLE
Document generate-features behavior with empty vehicle positions

### DIFF
--- a/docs/feature_engineering.md
+++ b/docs/feature_engineering.md
@@ -17,6 +17,12 @@ This project builds per-station snapshots for Sydney Metro to detect disruptions
    - network metrics: `node_degree`, `hub_flag`
    - presence indicators: `is_train_present`, `data_fresh_secs`
    A `route_id` column is included only when multiple routes appear in the snapshot.
+
+!!! note
+    If the ``vehicle_positions`` file exists but contains no rows for a given
+    snapshot minute, ``generate-features`` still writes the feature Parquet.
+    In this case ``is_train_present`` will be ``0`` and ``data_fresh_secs`` will
+    show a large value while delay-related features are unaffected.
 7. **Output** – The resulting DataFrame is indexed by `(stop_id, direction_id)` and written to `data/stations_features_time_series/year=YYYY/month=MM/day=DD/stations_feats_YYYY-DD-MM-HH-MM.parquet`.
    Filenames follow the `YYYY-DD-MM-HH-MM` convention.
 


### PR DESCRIPTION
## Summary
- describe that empty vehicle position files still yield features
- note values for `is_train_present` and `data_fresh_secs`

## Testing
- `pre-commit run --files docs/feature_engineering.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876955d1ed4832bb3735d48f092c01c