### PR TITLE
Handle empty RT parse results

### DIFF
--- a/src/metro_disruptions_intelligence/etl/parse_alerts.py
+++ b/src/metro_disruptions_intelligence/etl/parse_alerts.py
@@ -25,6 +25,9 @@ class AlertRow(BaseModel):
     url: Optional[str] = None
 
 
+ALERT_COLUMNS = list(AlertRow.__fields__.keys())
+
+
 def parse_one_alert_file(json_path: Path) -> pd.DataFrame:
     """Return a DataFrame of alerts contained in ``json_path``."""
     raw = json.loads(json_path.read_text())
@@ -59,4 +62,4 @@ def parse_one_alert_file(json_path: Path) -> pd.DataFrame:
                     ),
                 )
                 rows.append(row.dict())
-    return pd.DataFrame(rows)
+    return pd.DataFrame(rows, columns=ALERT_COLUMNS)

--- a/src/metro_disruptions_intelligence/etl/parse_trip_updates.py
+++ b/src/metro_disruptions_intelligence/etl/parse_trip_updates.py
@@ -27,6 +27,9 @@ class TripUpdateRow(BaseModel):
     departure_delay: int | None = None
 
 
+TRIP_UPDATE_COLUMNS = list(TripUpdateRow.__fields__.keys())
+
+
 def parse_one_trip_update_file(json_path: Path) -> pd.DataFrame:
     """Return all stop time updates contained in ``json_path``."""
     raw = json.loads(json_path.read_text())
@@ -55,4 +58,4 @@ def parse_one_trip_update_file(json_path: Path) -> pd.DataFrame:
                 departure_delay=float(stu.get("departure", {}).get("delay", 0.0) or 0.0),
             )
             rows.append(row.dict())
-    return pd.DataFrame(rows)
+    return pd.DataFrame(rows, columns=TRIP_UPDATE_COLUMNS)

--- a/src/metro_disruptions_intelligence/etl/parse_vehicle_positions.py
+++ b/src/metro_disruptions_intelligence/etl/parse_vehicle_positions.py
@@ -27,6 +27,9 @@ class VehiclePositionRow(BaseModel):
     occupancy_status: Optional[str] = None
 
 
+VEHICLE_POSITION_COLUMNS = list(VehiclePositionRow.__fields__.keys())
+
+
 def parse_one_vehicle_position_file(json_path: Path) -> pd.DataFrame:
     """Return a DataFrame of vehicle positions contained in ``json_path``."""
     raw = json.loads(json_path.read_text())
@@ -49,10 +52,16 @@ def parse_one_vehicle_position_file(json_path: Path) -> pd.DataFrame:
             bearing=pos.get("bearing"),
             speed=pos.get("speed"),
             current_stop_sequence=veh.get("current_stop_sequence"),
-            current_status=str(veh["current_status"]) if veh.get("current_status") is not None else None,
+            current_status=str(veh["current_status"])
+            if veh.get("current_status") is not None
+            else None,
             stop_id=veh.get("stop_id"),
-            congestion_level=str(veh["congestion_level"]) if veh.get("congestion_level") is not None else None,
-            occupancy_status=str(veh["occupancy_status"]) if veh.get("occupancy_status") is not None else None,
+            congestion_level=str(veh["congestion_level"])
+            if veh.get("congestion_level") is not None
+            else None,
+            occupancy_status=str(veh["occupancy_status"])
+            if veh.get("occupancy_status") is not None
+            else None,
         )
         rows.append(row.dict())
-    return pd.DataFrame(rows)
+    return pd.DataFrame(rows, columns=VEHICLE_POSITION_COLUMNS)

--- a/tests/test_parquet_delay_quality.py
+++ b/tests/test_parquet_delay_quality.py
@@ -23,7 +23,7 @@ def test_march_delay_non_null() -> None:
         pytest.skip("sample parquet files not available", allow_module_level=True)
     file = Path(
         "sample_data/rt_parquet/trip_updates/year=2025/month=03/day=06/"
-        "trip_updates_2025-06-03-16-49.parquet"
+        "trip_updates_2025-06-03-16-50.parquet"
     )
     df = pd.read_parquet(file)
     assert df["arrival_delay"].notna().mean() >= 0.95

--- a/tests/test_parse_empty_rt.py
+++ b/tests/test_parse_empty_rt.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from metro_disruptions_intelligence.etl.parse_alerts import ALERT_COLUMNS, parse_one_alert_file
+from metro_disruptions_intelligence.etl.parse_trip_updates import (
+    TRIP_UPDATE_COLUMNS,
+    parse_one_trip_update_file,
+)
+from metro_disruptions_intelligence.etl.parse_vehicle_positions import (
+    VEHICLE_POSITION_COLUMNS,
+    parse_one_vehicle_position_file,
+)
+
+EMPTY_JSON = '{"header": {"timestamp": 0}, "entity": []}'
+
+
+def _write_empty(path: Path) -> None:
+    path.write_text(EMPTY_JSON, encoding="utf-8")
+
+
+def test_empty_trip_update(tmp_path: Path) -> None:
+    file = tmp_path / "tu.json"
+    _write_empty(file)
+    df = parse_one_trip_update_file(file)
+    assert df.empty
+    assert list(df.columns) == TRIP_UPDATE_COLUMNS
+
+
+def test_empty_vehicle_position(tmp_path: Path) -> None:
+    file = tmp_path / "vp.json"
+    _write_empty(file)
+    df = parse_one_vehicle_position_file(file)
+    assert df.empty
+    assert list(df.columns) == VEHICLE_POSITION_COLUMNS
+
+
+def test_empty_alert(tmp_path: Path) -> None:
+    file = tmp_path / "alert.json"
+    _write_empty(file)
+    df = parse_one_alert_file(file)
+    assert df.empty
+    assert list(df.columns) == ALERT_COLUMNS


### PR DESCRIPTION
## Summary
- ensure trip update, vehicle position and alert parsers return DataFrame with all columns even when no rows
- update quality test to use an existing sample file
- add tests for parsing empty realtime JSON data

## Testing
- `pytest -n0 -q`

------
https://chatgpt.com/codex/tasks/task_e_6877a1d0f894832bbd47e0d76491129d