### PR TITLE
Add header-only GTFS-RT tests

### DIFF
--- a/tests/test_header_only_pipeline.py
+++ b/tests/test_header_only_pipeline.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+import pytz
+
+from metro_disruptions_intelligence.etl.ingest_rt import FEEDS, ingest_all_rt, union_all_feeds
+from metro_disruptions_intelligence.features import SnapshotFeatureBuilder
+from metro_disruptions_intelligence.processed_reader import compose_path
+
+HEADER_JSON = '{"header": {"timestamp": 0}}'
+
+
+def _write_header_only(path: Path) -> None:
+    path.write_text(HEADER_JSON, encoding="utf-8")
+
+
+def test_pipeline_header_only(tmp_path: Path) -> None:
+    raw_root = tmp_path / "raw"
+    for feed in FEEDS:
+        feed_dir = raw_root / feed
+        feed_dir.mkdir(parents=True, exist_ok=True)
+        _write_header_only(feed_dir / "2020_01_01_00_00_00.json")
+
+    processed_root = tmp_path / "processed" / "rt"
+    ingest_all_rt(raw_root, processed_root)
+    union_all_feeds(processed_root, processed_root.parent / "station_event.parquet")
+
+    ts = int(datetime(2020, 1, 1, tzinfo=pytz.UTC).timestamp())
+    tu = pd.read_parquet(compose_path(ts, processed_root, "trip_updates"))
+    vp = pd.read_parquet(compose_path(ts, processed_root, "vehicle_positions"))
+
+    builder = SnapshotFeatureBuilder({("R", 0): ["STOP"]})
+    builder.build_snapshot_features(tu, vp, ts)

--- a/tests/test_parse_header_only_rt.py
+++ b/tests/test_parse_header_only_rt.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from metro_disruptions_intelligence.etl.parse_alerts import ALERT_COLUMNS, parse_one_alert_file
+from metro_disruptions_intelligence.etl.parse_trip_updates import (
+    TRIP_UPDATE_COLUMNS,
+    parse_one_trip_update_file,
+)
+from metro_disruptions_intelligence.etl.parse_vehicle_positions import (
+    VEHICLE_POSITION_COLUMNS,
+    parse_one_vehicle_position_file,
+)
+
+HEADER_JSON = '{"header": {"timestamp": 0}}'
+
+
+def _write_header_only(path: Path) -> None:
+    path.write_text(HEADER_JSON, encoding="utf-8")
+
+
+def test_header_only_trip_update(tmp_path: Path) -> None:
+    file = tmp_path / "tu.json"
+    _write_header_only(file)
+    df = parse_one_trip_update_file(file)
+    assert df.empty
+    assert list(df.columns) == TRIP_UPDATE_COLUMNS
+
+
+def test_header_only_vehicle_position(tmp_path: Path) -> None:
+    file = tmp_path / "vp.json"
+    _write_header_only(file)
+    df = parse_one_vehicle_position_file(file)
+    assert df.empty
+    assert list(df.columns) == VEHICLE_POSITION_COLUMNS
+
+
+def test_header_only_alert(tmp_path: Path) -> None:
+    file = tmp_path / "alert.json"
+    _write_header_only(file)
+    df = parse_one_alert_file(file)
+    assert df.empty
+    assert list(df.columns) == ALERT_COLUMNS


### PR DESCRIPTION
## Summary
- ensure feed parsers handle header-only JSON
- test ingestion pipeline and feature generation with header-only files

## Testing
- `pre-commit run --files tests/test_parse_header_only_rt.py tests/test_header_only_pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877a5b9eae8832b8d3680cab4d88298