### PR TITLE
Add new features for congestion and central station

### DIFF
--- a/docs/feature_engineering.md
+++ b/docs/feature_engineering.md
@@ -14,7 +14,8 @@ This project builds per-station snapshots for Sydney Metro to detect disruptions
    - `upstream_delay_mean_2`, `downstream_delay_max_2`
    - rolling statistics: `delay_mean_5`, `delay_std_5`, `delay_mean_15`, `headway_p90_60`
    - time features: `sin_hour`, `cos_hour`, `day_type`
-   - network metrics: `node_degree`, `hub_flag`
+   - network metrics: `node_degree`, `hub_flag`, `central_flag`
+   - vehicle metrics: `congestion_level`, `occupancy_status`
    - presence indicators: `is_train_present`, `data_fresh_secs`
    A `route_id` column is included only when multiple routes appear in the snapshot.
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -24,6 +24,8 @@ def test_build_snapshot_features() -> None:
     feats = builder.build_snapshot_features(trip_now, veh_now, ts)
     assert not feats.empty
     assert isinstance(feats.index, pd.MultiIndex)
+    assert {"congestion_level", "occupancy_status", "central_flag"}.issubset(feats.columns)
+    assert feats.loc[("2000466", 0), "central_flag"] == 1
 
 
 def test_headway_bounds() -> None:


### PR DESCRIPTION
## Summary
- incorporate Central station stop list
- expose `congestion_level`, `occupancy_status`, and `central_flag` in snapshot features
- test new metrics
- document additional generated feature columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a695b2e6c832babf17e5258e6f326