### PR TITLE
Expand CENTRAL_STOP_IDS and update tests

### DIFF
--- a/src/metro_disruptions_intelligence/features.py
+++ b/src/metro_disruptions_intelligence/features.py
@@ -12,7 +12,17 @@ import pandas as pd
 from .utils_gtfsrt import CONSTANTS, is_new_service_day, sydney_time
 
 # Sydney Metro stop_ids for Central station
-CENTRAL_STOP_IDS = {"2000466", "2000467", "200060"}
+CENTRAL_STOP_IDS = {
+    "2000466",
+    "2000467",
+    "200060",
+    "2065163",
+    "2060115",
+    "2000460",
+    "2000463",
+    "2000464",
+    "2017078",
+}
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -25,7 +25,7 @@ def test_build_snapshot_features() -> None:
     assert not feats.empty
     assert isinstance(feats.index, pd.MultiIndex)
     assert {"congestion_level", "occupancy_status", "central_flag"}.issubset(feats.columns)
-    assert feats.loc[("2000466", 0), "central_flag"] == 1
+    assert feats.loc[("2065163", 1), "central_flag"] == 1
 
 
 def test_headway_bounds() -> None:


### PR DESCRIPTION
## Summary
- extend `CENTRAL_STOP_IDS` to cover all Central station stop IDs
- verify the `central_flag` for a new stop in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6d84e2bc832b9a29c1002472127a