### PR TITLE
Add streaming IForest detector

### DIFF
--- a/configs/iforest_default.yaml
+++ b/configs/iforest_default.yaml
@@ -1,0 +1,6 @@
+n_trees: 100
+height: 10
+subsample_size: 256
+window_size: 10000
+threshold_quantile: 0.97
+warmup_days: 4

--- a/configs/iforest_grid.yaml
+++ b/configs/iforest_grid.yaml
@@ -1,0 +1,15 @@
+n_trees:
+  - 50
+  - 100
+height:
+  - 8
+  - 10
+subsample_size:
+  - 128
+  - 256
+window_size:
+  - 5000
+  - 10000
+threshold_quantile:
+  - 0.97
+  - 0.98

--- a/src/metro_disruptions_intelligence/detect/__init__.py
+++ b/src/metro_disruptions_intelligence/detect/__init__.py
@@ -1,0 +1,5 @@
+"""Streaming anomaly detection utilities."""
+
+from .streaming_iforest import IForestConfig, StreamingIForestDetector
+
+__all__ = ["IForestConfig", "StreamingIForestDetector"]

--- a/src/metro_disruptions_intelligence/detect/shap_utils.py
+++ b/src/metro_disruptions_intelligence/detect/shap_utils.py
@@ -1,0 +1,16 @@
+"""Helper utilities for SHAP-like explanations."""
+
+from __future__ import annotations
+
+
+def top_n_tree_shap(model, x: dict[str, float], n: int = 3) -> list[tuple[str, float]]:
+    """Return top-N feature contributions using a simple ablation approach."""
+    base = model.score_one(x)
+    scores: list[tuple[str, float]] = []
+    for k in x:
+        x0 = dict(x)
+        x0[k] = 0
+        diff = base - model.score_one(x0)
+        scores.append((k, diff))
+    scores.sort(key=lambda kv: abs(kv[1]), reverse=True)
+    return scores[:n]

--- a/src/metro_disruptions_intelligence/detect/streaming_iforest.py
+++ b/src/metro_disruptions_intelligence/detect/streaming_iforest.py
@@ -1,0 +1,184 @@
+"""Streaming Isolation Forest detector using River."""
+
+from __future__ import annotations
+
+import json
+import logging
+import pickle
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from river import anomaly, compose
+
+from ..utils_gtfsrt import sydney_time
+from .shap_utils import top_n_tree_shap
+
+logger = logging.getLogger(__name__)
+
+BAD_STOP_IDS = {"204472", "2155270"}
+
+
+@dataclass
+class IForestConfig:
+    """Hyper-parameters for :class:`StreamingIForestDetector`."""
+
+    n_trees: int = 100
+    height: int = 10
+    subsample_size: int = 256
+    window_size: int = 10_000
+    threshold_quantile: float = 0.97
+    warmup_days: int = 4
+
+
+class StreamingIForestDetector:
+    """Online anomaly detector based on Half-Space Trees."""
+
+    def __init__(self, config: IForestConfig | dict | str | Path) -> None:
+        """Initialise the detector with ``config``."""
+        if isinstance(config, (str, Path)):
+            cfg_dict = self._load_yaml(Path(config))
+            self.config = IForestConfig(**cfg_dict)
+        elif isinstance(config, dict):
+            self.config = IForestConfig(**config)
+        else:
+            self.config = config
+
+        self._build_pipeline()
+        self.scores: deque[float] = deque(maxlen=self.config.window_size)
+        self.n_obs = 0
+        self.current_service_day: Any = None
+        self.feature_cols: list[str] | None = None
+
+    @staticmethod
+    def _load_yaml(path: Path) -> dict:
+        import yaml
+
+        with open(path, encoding="utf-8") as f:
+            return yaml.safe_load(f)
+
+    def _build_pipeline(self) -> None:
+        self.pipeline = compose.Pipeline(
+            # ("scale", preprocessing.MinMaxScaler()),
+            anomaly.HalfSpaceTrees(
+                n_trees=self.config.n_trees,
+                height=self.config.height,
+                window_size=self.config.window_size,
+            )
+        )
+
+    # ------------------------------------------------------------------
+    def _service_day(self, ts: int) -> Any:
+        dt = sydney_time(ts)
+        if dt.hour < 3:
+            dt -= pd.Timedelta(days=1)
+        return dt.date()
+
+    def _maybe_reset(self, ts: int) -> None:
+        sd = self._service_day(ts)
+        if self.current_service_day is None:
+            self.current_service_day = sd
+        elif sd != self.current_service_day:
+            logger.info("Service day boundary reached – resetting state")
+            self._build_pipeline()
+            self.scores.clear()
+            self.n_obs = 0
+            self.current_service_day = sd
+
+    # ------------------------------------------------------------------
+    def score_and_update(self, df_minute: pd.DataFrame, *, explain: bool = False) -> pd.DataFrame:
+        """Score each snapshot in ``df_minute`` and update the model."""
+        if df_minute.empty:
+            return pd.DataFrame(
+                columns=[
+                    "ts",
+                    "stop_id",
+                    "direction_id",
+                    "anomaly_score",
+                    "anomaly_flag",
+                    "shap_top3_json",
+                ]
+            )
+
+        ts = int(df_minute["snapshot_timestamp"].iloc[0])
+        self._maybe_reset(ts)
+
+        df = df_minute.copy()
+        df = df[~df["stop_id"].astype(str).isin(BAD_STOP_IDS)]
+        df.fillna(0, inplace=True)
+        numeric_cols = df.select_dtypes(include=[np.number]).columns.tolist()
+        df = df[(df[numeric_cols].abs().sum(axis=1) != 0)]
+
+        if df.empty:
+            return pd.DataFrame(
+                columns=[
+                    "ts",
+                    "stop_id",
+                    "direction_id",
+                    "anomaly_score",
+                    "anomaly_flag",
+                    "shap_top3_json",
+                ]
+            )
+
+        if self.feature_cols is None:
+            exclude = {"snapshot_timestamp", "stop_id", "direction_id", "local_dt"}
+            self.feature_cols = [c for c in df.columns if c not in exclude]
+
+        rows = []
+        for _, row in df.iterrows():
+            x = {k: row[k] for k in self.feature_cols}
+            score = float(self.pipeline.score_one(x))
+            self.scores.append(score)
+            self.n_obs += 1
+
+            flag = 0
+            if self.n_obs >= self.config.window_size:
+                threshold = float(np.quantile(self.scores, self.config.threshold_quantile))
+                if score > threshold:
+                    flag = 1
+
+            shap_json = None
+            if explain:
+                shap_json = json.dumps(top_n_tree_shap(self.pipeline[-1], x, n=3))
+
+            rows.append({
+                "ts": ts,
+                "stop_id": row["stop_id"],
+                "direction_id": row["direction_id"],
+                "anomaly_score": score,
+                "anomaly_flag": flag if self.n_obs >= self.config.window_size else 0,
+                "shap_top3_json": shap_json,
+            })
+            self.pipeline.learn_one(x)
+        return pd.DataFrame(rows)
+
+    # ------------------------------------------------------------------
+    def save(self, path: str | Path) -> None:
+        """Persist the detector to ``path``."""
+        state = {
+            "config": self.config.__dict__,
+            "pipeline": self.pipeline,
+            "scores": list(self.scores),
+            "n_obs": self.n_obs,
+            "current_service_day": self.current_service_day,
+            "feature_cols": self.feature_cols,
+        }
+        with open(path, "wb") as f:
+            pickle.dump(state, f)
+
+    @classmethod
+    def load(cls, path: str | Path) -> StreamingIForestDetector:
+        """Load a persisted detector from ``path``."""
+        with open(path, "rb") as f:
+            state = pickle.load(f)
+        obj = cls(state["config"])
+        obj.pipeline = state["pipeline"]
+        obj.scores = deque(state["scores"], maxlen=obj.config.window_size)
+        obj.n_obs = state["n_obs"]
+        obj.current_service_day = state["current_service_day"]
+        obj.feature_cols = state["feature_cols"]
+        return obj

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+import pandas as pd
+
+from metro_disruptions_intelligence.detect.streaming_iforest import (
+    IForestConfig,
+    StreamingIForestDetector,
+)
+
+
+def make_df(ts: int, stop_ids: list[str]) -> pd.DataFrame:
+    data = {
+        "snapshot_timestamp": [ts] * len(stop_ids),
+        "stop_id": stop_ids,
+        "direction_id": [0] * len(stop_ids),
+        "node_degree": [1] * len(stop_ids),
+        "hub_flag": [0] * len(stop_ids),
+        "central_flag": [0] * len(stop_ids),
+        "congestion_level": [1] * len(stop_ids),
+        "occupancy": [2] * len(stop_ids),
+    }
+    return pd.DataFrame(data)
+
+
+def test_filter_bad_stops() -> None:
+    det = StreamingIForestDetector(IForestConfig())
+    df = make_df(0, ["1", "204472", "2"])
+    out = det.score_and_update(df)
+    assert set(out["stop_id"]) == {"1", "2"}
+
+
+def test_all_zero_skipped() -> None:
+    det = StreamingIForestDetector(IForestConfig())
+    df = make_df(0, ["1"])
+    df.loc[:, ["node_degree", "hub_flag", "central_flag", "congestion_level", "occupancy"]] = 0
+    out = det.score_and_update(df)
+    assert out.empty
+
+
+def test_warmup_no_alerts() -> None:
+    cfg = IForestConfig(window_size=10)
+    det = StreamingIForestDetector(cfg)
+    df = make_df(0, ["1"] * 10)
+    out = det.score_and_update(df)
+    assert out["anomaly_flag"].sum() == 0
+
+
+def test_service_day_reset() -> None:
+    cfg = IForestConfig(window_size=5)
+    det = StreamingIForestDetector(cfg)
+    df1 = make_df(1714665600, ["1"])  # 2024-05-03 02:00 UTC -> 12:00 Sydney
+    det.score_and_update(df1)
+    assert det.n_obs == 1
+    df2 = make_df(1714669800, ["1"])  # later same day 03:00 UTC -> 13:00 Sydney
+    det.score_and_update(df2)
+    assert det.n_obs == 1
+    df3 = make_df(1714755900, ["1"])  # next day 03:00 Sydney
+    det.score_and_update(df3)
+    assert det.n_obs == 1
+
+
+def test_save_load_roundtrip(tmp_path: Path) -> None:
+    cfg = IForestConfig(window_size=5)
+    det = StreamingIForestDetector(cfg)
+    df = make_df(0, ["1"])
+    det.score_and_update(df)
+    p = tmp_path / "model.pkl"
+    det.save(p)
+    det2 = StreamingIForestDetector.load(p)
+    df2 = make_df(60, ["1"])
+    out1 = det.score_and_update(df2)
+    out2 = det2.score_and_update(df2)
+    pd.testing.assert_frame_equal(out1, out2)


### PR DESCRIPTION
## Summary
- implement StreamingIForestDetector with save/load helpers
- provide SHAP helper
- add default and grid configuration files
- include unit tests for detection logic

## Testing
- `ruff format ...`
- `ruff check ...`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b7d4c39c4832b9de250a6d7c335fc