### PR TITLE
Fix missing river dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ click
 numpy
 pandas
 PyYAML
+river

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,6 +6,7 @@ pyarrow
 duckdb
 pydantic
 numpy
+river
 requests
 tqdm
 


### PR DESCRIPTION
## Summary
- add `river` to minimal requirements so `StreamingIForestDetector` tests run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b845ab6e4832b8f17e81831594383