### PR TITLE
Add warning for low sample sizes in anomaly notebook

### DIFF
--- a/notebooks/04_run_anomaly_detection.ipynb
+++ b/notebooks/04_run_anomaly_detection.ipynb
@@ -49,6 +49,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note:** `StreamingIForestDetector` uses a default `subsample_size` of 256. ",
+    "Running it on fewer observations (like the synthetic example below) will ",
+    "yield zero anomaly scores. For small samples you can pass a custom ",
+    "configuration:\n",
+    "```python\n",
+    "from metro_disruptions_intelligence.detect import IForestConfig\n",
+    "det = StreamingIForestDetector(IForestConfig(subsample_size=50))\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "e54b5985",


### PR DESCRIPTION
## Summary
- note default subsample size in anomaly detection notebook
- show how to customise the detector for small samples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bcdf3145c832bbb67e6b208caf38a