### PR TITLE
Fix anomaly detection example to read feature files

### DIFF
--- a/notebooks/04_run_anomaly_detection.ipynb
+++ b/notebooks/04_run_anomaly_detection.ipynb
@@ -52,9 +52,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note:** `StreamingIForestDetector` uses a default `subsample_size` of 256. \n",
-    "Running it on fewer observations (like the synthetic example below) will \n",
-    "yield zero anomaly scores. For small samples you can pass a custom \n",
+    "**Note:** `StreamingIForestDetector` uses a default `subsample_size` of 256.\n",
+    "Running it on fewer observations (like the small example below) will\n",
+    "yield zero anomaly scores. For small samples you can pass a custom\n",
     "configuration:\n",
     "```python\n",
     "from metro_disruptions_intelligence.detect import IForestConfig\n",
@@ -93,37 +93,41 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The features should be stored in `data/stations_features_time_series` as described in the documentation.\n",
+    "If this directory is empty you must generate the Parquet files first."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "ebdd2fba",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# 4. Stream 2 hours of synthetic data\n",
-    "import json\n",
+    "# 4. Stream 2 hours of feature data\n",
     "from datetime import datetime, timedelta\n",
-    "\n",
+    "import json\n",
+    "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
     "\n",
     "start = datetime(2023, 5, 1, 0, 0)\n",
+    "end = start + timedelta(hours=2)\n",
     "rows = []\n",
     "det = StreamingIForestDetector(config_path)\n",
-    "for i in range(120):\n",
-    "    ts = int((start + timedelta(minutes=i)).timestamp())\n",
-    "    df = pd.DataFrame({\n",
-    "        \"snapshot_timestamp\": [ts],\n",
-    "        \"stop_id\": [\"100\"],\n",
-    "        \"direction_id\": [0],\n",
-    "        \"central_flag\": [1],\n",
-    "        \"congestion_level\": [np.random.rand()],\n",
-    "        \"occupancy\": [np.random.rand()],\n",
-    "        \"node_degree\": [2],\n",
-    "        \"hub_flag\": [0],\n",
-    "    })\n",
+    "for ts in range(int(start.timestamp()), int(end.timestamp()), 60):\n",
+    "    dt = datetime.fromtimestamp(ts)\n",
+    "    f = (\n",
+    "        processed_root / f\"year={dt.year:04d}\" / f\"month={dt.month:02d}\" / f\"day={dt.day:02d}\" / f\"stations_feats_{dt:%Y-%d-%m-%H-%M}.parquet\"\n",
+    "    )\n",
+    "    if not f.exists():\n",
+    "        continue\n",
+    "    df = pd.read_parquet(f)\n",
     "    out = det.score_and_update(df, explain=True)\n",
     "    rows.append(out)\n",
-    "scores = pd.concat(rows, ignore_index=True)"
+    "scores = pd.concat(rows, ignore_index=True)\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- load actual feature Parquets in `04_run_anomaly_detection` instead of random data
- clarify that feature files live in `data/stations_features_time_series`
- document how to stream a time range of feature files in `anomaly_detection.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd749f92c832b9424602bfb003a61